### PR TITLE
Remove deprecated set-env commands from GitHub Actions workflows

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -18,6 +18,17 @@ jobs:
         run: echo 'Workspace directory is ${{ github.workspace }}'
       - name: Run a simple echo command with a pre-set environment variable
         run: echo 'Hello World, from ${{ env.APP_NAME }}'
+      - name: Set an environment variable using a multi-line string
+        run: |
+          echo "MULTI_LINE_STRING<<EOF" >> $GITHUB_ENV
+          echo "
+            Hello World!
+            Here's a
+            multi-line string.
+          " >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Check the environment variable from the previous step
+        run: echo $MULTI_LINE_STRING
       - name: Set build environment based on Git branch name
         if: github.ref == 'refs/heads/demo' || contains(env.APP_NAME, 'demo')
         run: echo "BUILD_ENV=demo" >> $GITHUB_ENV

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -20,15 +20,15 @@ jobs:
         run: echo 'Hello World, from ${{ env.APP_NAME }}'
       - name: Set build environment based on Git branch name
         if: github.ref == 'refs/heads/demo' || contains(env.APP_NAME, 'demo')
-        run: echo ::set-env name=BUILD_ENV::"demo"
+        run: echo "BUILD_ENV=demo" >> $GITHUB_ENV
       - name: Use the GitHub Actions format function to provide some details about Spam
         run: |
-          echo ::set-env name=SPAM_STRING::${{ format(
+          echo "SPAM_STRING=${{ format(
             'Spam is short for {0} and is made from {1} by {2}',
             'spiced ham',
             'pork shoulder',
             'Hormel'
-          ) }}
+          ) }}" >> $GITHUB_ENV
       - name: Run a multi-line shell script block
         run: |
           echo "

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -13,15 +13,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Set PY environment variable for pre-commit
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
       - name: Set up pre-commit cache
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ env.PY }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: ${{ runner.os }}-pre-commit-${{ env.PY }}-
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: ${{ runner.os }}-pre-commit-
       - name: Install dependencies
         run: python -m pip install pre-commit
       - name: Run pre-commit hooks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,15 +17,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - name: Set PY environment variable for caching
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
       - name: Set up Poetry cache for Python dependencies
         uses: actions/cache@v2
         if: startsWith(runner.os, 'Linux')
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-${{ env.PY }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: ${{ runner.os }}-poetry-${{ env.PY }}-
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
       - name: Install dependencies
         working-directory: py
         run: |


### PR DESCRIPTION
## Description

GitHub Actions provides a set of [workflow commands](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions) to improve programmatic control over workflow steps. One useful command was `::set-env`, which sets environment variables for workflow jobs.

GitHub has [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) `::set-env` due to a [moderate security vulnerability](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w), and has provided updated syntax for working with [environment variables in workflows](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).

```sh
# single-line environment variable
echo "VARIABLE_NAME=value" >> $GITHUB_ENV

# multi-line environment variable
echo "VARIABLE_NAME<<EOF" >> $GITHUB_ENV
echo "
  Hello World!
  Here's a
  multi-line string.
" >> $GITHUB_ENV
echo "EOF" >> $GITHUB_ENV

# updating PATH
echo "/path/to/dir" >> $GITHUB_PATH

```

This PR will update the GitHub Actions workflows with the new environment file syntax.

## Changes

- Remove Python version from GitHub Actions cache (2a434a4)
- Remove deprecated GitHub Actions set-env syntax (c46777f)
- Add GitHub Actions multi-line string example (58b7e32)

## Related

[Getting the Gist of GitHub Actions](https://gist.github.com/f9c753eb27381f97336aa21b8d932be6)

[POSIX standard: Shell Command Language](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html) - See section 2.7 for instructions on using delimiters like `EOF` with redirected input (the "here-document", which can come from a multi-line string, JSON document, or other source).

- [x] I have reviewed the [Guidelines for Contributing](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).